### PR TITLE
Use deploy key in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,5 +32,5 @@ jobs:
           git config --global user.name 'Storyscript Infrastructure'
           git config --global user.email 'infra@storyscript.io'
           git add index.yaml
-          git commit -m "Update index.yaml"
+          git diff-index --quiet HEAD || git commit -m "Update index.yaml"
           git push

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,10 @@ jobs:
         run: |
           git config --global user.name 'Storyscript Infrastructure'
           git config --global user.email 'infra@storyscript.io'
+          mkdir "${HOME}/.ssh"
+          echo "${{ secrets.DEPLOY_KEY }}" > "${HOME}/.ssh/id_rsa"
+          chmod 400 "${HOME}/.ssh/id_rsa"
+          git remote add github git@github.com:${{ github.repository }}.git
           git add index.yaml
           git diff-index --quiet HEAD || git commit -m "Update index.yaml"
-          git push
+          GIT_SSH_COMMAND="ssh -i ${HOME}/.ssh/id_rsa -o StrictHostKeyChecking=no" git push github


### PR DESCRIPTION
Fixes #9 

Created an SSH key using `ssh-keygen -t rsa -b 4096 -C "infra@storyscript.io"` . 
Added the public key as the `publish_chart` deploy key and the private key as the `DEPLOY_KEY` secret.