### PR TITLE
Release 0.7.0

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 name: storyscript
-version: 0.6.0
+version: 0.7.0
 description: A Helm chart for Storyscript


### PR DESCRIPTION
This release allows setting the hub api URI for the SLS, so that it isn't always pointing at "production"