### PR TITLE
feat(proxy): add nginx proxy

### DIFF
--- a/templates/proxy/proxy.configmap.yaml
+++ b/templates/proxy/proxy.configmap.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{ .Release.Name }}-proxy-conf"
+data:
+  nginx.conf: |
+    user nginx;
+    events {
+    }
+    http {
+      upstream landing {
+        server storyscript.netlify.com:443;
+      }
+
+      upstream studio {
+        server studio.{{ .Values.domain }}:443;
+      }
+
+      server {
+        listen 80 default_server;
+        server_name {{ .Values.domain }} www.{{ .Values.domain }};
+
+        location = / {
+            proxy_set_header Host www.{{ .Values.domain }};
+            proxy_pass https://landing;
+            proxy_cache_revalidate on;
+        }
+
+        location / {
+            try_files $uri @static_landing;
+        }
+
+        location @static_landing {
+            proxy_set_header Host www.{{ .Values.domain }};
+            proxy_pass https://landing$uri;
+
+            proxy_intercept_errors on;
+            recursive_error_pages on;
+            error_page 404 = @static_studio;
+        }
+
+        location @static_studio {
+            proxy_set_header Host studio.{{ .Values.domain }};
+            proxy_pass https://studio$uri;
+        }
+      }
+    }

--- a/templates/proxy/proxy.deployment.yaml
+++ b/templates/proxy/proxy.deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: "{{ .Release.Name }}-proxy"
+spec:
+  selector:
+    matchLabels:
+      app: proxy
+  template:
+    metadata:
+      labels:
+        app: proxy
+    spec:
+      volumes:
+      - name: "{{ .Release.Name }}-proxy-conf"
+        configMap:
+          name: "{{ .Release.Name }}-proxy-conf"
+          items:
+            - key: nginx.conf
+              path: nginx.conf
+      containers:
+        - name: nginx
+          image: nginx
+          ports:
+          - containerPort: 80
+          volumeMounts:
+          - mountPath: /etc/nginx
+            readOnly: true
+            name: "{{ .Release.Name }}-proxy-conf"

--- a/templates/proxy/proxy.ingress.yaml
+++ b/templates/proxy/proxy.ingress.yaml
@@ -1,0 +1,27 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: "{{ .Release.Name }}-proxy"
+  labels:
+    app: proxy
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/server-alias: "www.{{ .Values.domain }}"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+spec:
+  {{- if .Values.tls.enabled }}
+  tls:
+  - hosts:
+    - "{{ .Values.domain }}"
+    - "www.{{ .Values.domain }}"
+    secretName: "{{ .Release.Name }}-tls-cert"
+  {{- end }}
+  rules:
+  - host: "{{ .Values.domain }}"
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: "{{ .Release.Name }}-proxy"
+          servicePort: 80

--- a/templates/proxy/proxy.service.yaml
+++ b/templates/proxy/proxy.service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ .Release.Name }}-proxy"
+  labels:
+    app: proxy
+spec:
+  selector:
+    app: proxy
+  type: LoadBalancer
+  ports:
+  - port: 80
+    name: external
+    protocol: TCP
+    targetPort: 80


### PR DESCRIPTION
it try to load everything under netlify, then studio
it forces the validation of the index route, so the studio / is not cached there

---

### Acceptance

**When** I navigate to `storyscript.com/example/autolabel/`
**Then** I see the Story in the studio
