### PR TITLE
feat(graphql): add RUNTIME_URL to the graphql deployment

### DIFF
--- a/templates/graphql/graphql.deployment.yaml
+++ b/templates/graphql/graphql.deployment.yaml
@@ -33,3 +33,5 @@ spec:
               value: {{ .Values.graphql.corsWhitelistRegexp }}
             - name: CREDS_URL
               value: {{ printf "http://%s-creds.%s.svc.cluster.local:9000" .Release.Name .Release.Namespace }}
+            - name: RUNTIME_URL
+              value: {{ printf "http://%s-runtime.%s.svc.cluster.local:9001" .Release.Name .Release.Namespace }}


### PR DESCRIPTION
In order to make the GQL server able to query the services and builtins specification from the runtime. I had to add the RUNTIME_URL as an environment variable.

Needed for:
- https://github.com/storyscript/graphql/pull/25
- https://github.com/storyscript/runtime/pull/37

See https://github.com/storyscript/graphql/pull/25/files#diff-b86d9cde4c78c60aec75d1585bbba019R44-R46