### PR TITLE
feat(github): add github_app id + private key values

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 name: storyscript
-version: 0.26.0
+version: 0.28.0
 description: A Helm chart for Storyscript

--- a/templates/runtime/runtime.deployment.yaml
+++ b/templates/runtime/runtime.deployment.yaml
@@ -37,3 +37,13 @@ spec:
                 secretKeyRef:
                   name: "{{ .Release.Name }}-runtime"
                   key: wolfram_app_id
+            - name: GITHUB_APP_ID
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Release.Name }}-runtime"
+                  key: github_app_id
+            - name: GITHUB_APP_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Release.Name }}-runtime"
+                  key: github_app_private_Key

--- a/templates/runtime/runtime.deployment.yaml
+++ b/templates/runtime/runtime.deployment.yaml
@@ -46,4 +46,4 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: "{{ .Release.Name }}-runtime"
-                  key: github_app_private_Key
+                  key: github_app_private_key

--- a/templates/runtime/runtime.secrets.yml
+++ b/templates/runtime/runtime.secrets.yml
@@ -5,5 +5,5 @@ metadata:
 type: Opaque
 data:
   wolfram_app_id: {{ required "A .Values.runtime.wolfram_app_id is required" .Values.runtime.wolfram_app_id | b64enc }}
-  github_app_id: {{ required "A .Values.runtime.github.app_id is required" .Values.runtime.github_app.id | b64enc }}
-  github_app_private_Key: {{ required "A .Values.runtime.github.app_private_key is required" .Values.runtime.github_app.private_key | b64enc }}
+  github_app_id: {{ required "A .Values.runtime.github.app_id is required" .Values.runtime.github.app_id | b64enc }}
+  github_app_private_key: {{ required "A .Values.runtime.github.app_private_key is required" .Values.runtime.github.app_private_key | b64enc }}

--- a/templates/runtime/runtime.secrets.yml
+++ b/templates/runtime/runtime.secrets.yml
@@ -5,3 +5,5 @@ metadata:
 type: Opaque
 data:
   wolfram_app_id: {{ required "A .Values.runtime.wolfram_app_id is required" .Values.runtime.wolfram_app_id | b64enc }}
+  github_app_id: {{ required "A .Values.runtime.github_app.id is required" .Values.runtime.github_app.id | b64enc }}
+  github_app_private_Key: {{ required "A .Values.runtime.github_app.private_key is required" .Values.runtime.github_app.private_key | b64enc }}

--- a/templates/runtime/runtime.secrets.yml
+++ b/templates/runtime/runtime.secrets.yml
@@ -5,5 +5,5 @@ metadata:
 type: Opaque
 data:
   wolfram_app_id: {{ required "A .Values.runtime.wolfram_app_id is required" .Values.runtime.wolfram_app_id | b64enc }}
-  github_app_id: {{ required "A .Values.runtime.github_app.id is required" .Values.runtime.github_app.id | b64enc }}
-  github_app_private_Key: {{ required "A .Values.runtime.github_app.private_key is required" .Values.runtime.github_app.private_key | b64enc }}
+  github_app_id: {{ required "A .Values.runtime.github.app_id is required" .Values.runtime.github_app.id | b64enc }}
+  github_app_private_Key: {{ required "A .Values.runtime.github.app_private_key is required" .Values.runtime.github_app.private_key | b64enc }}

--- a/values.yaml
+++ b/values.yaml
@@ -104,6 +104,9 @@ runtime:
     repository: storyscript/runtime
     tag: v0.6.0
   wolfram_app_id:
+  github_app:
+    id:
+    private_key:
 
 worker:
   image:

--- a/values.yaml
+++ b/values.yaml
@@ -109,9 +109,9 @@ runtime:
     repository: storyscript/runtime
     tag: v0.8.0
   wolfram_app_id:
-  github_app:
-    id:
-    private_key:
+  github:
+    app_id:
+    app_private_key:
 
 worker:
   image:


### PR DESCRIPTION
Should we include the GitHub Dev app values into the CI for our dev platforms ?

https://github.com/organizations/storyscript/settings/apps/storyscript-development

-> values are stored into lastpass already