### PR TITLE
Ensure compiler can get typing information

### DIFF
--- a/templates/compiler/compiler.deployment.yaml
+++ b/templates/compiler/compiler.deployment.yaml
@@ -17,3 +17,11 @@ spec:
           ports:
             - name: compiler
               containerPort: 5001
+          env:
+            - name: GRAPHQL_URL
+              value: {{ printf "http://%s-graphql.%s.svc.cluster.local:3000/graphql" .Release.Name .Release.Namespace }}
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Release.Name }}-database-credentials"
+                  key: superuser

--- a/templates/graphql/graphql.deployment.yaml
+++ b/templates/graphql/graphql.deployment.yaml
@@ -24,7 +24,6 @@ spec:
                   name: "{{ .Release.Name }}-auth"
                   key: jwt_secret_key
             - name: DATABASE_URL
-              # used to connect to db
               valueFrom:
                 secretKeyRef:
                   name: "{{ .Release.Name }}-database-credentials"
@@ -33,3 +32,5 @@ spec:
               value: {{ .Values.graphql.corsWhitelistRegexp }}
             - name: CREDS_URL
               value: {{ printf "http://%s-creds.%s.svc.cluster.local:9000" .Release.Name .Release.Namespace }}
+            - name: RUNTIME_URL
+              value: {{ printf "http://%s-runtime.%s.svc.cluster.local:9001" .Release.Name .Release.Namespace }}


### PR DESCRIPTION
The compiler needs graphql to look up service typing information: https://github.com/storyscript/language/commit/25669dc634247629bc87af0e4365f9da82fd3319

Graphql needs the runtime to get service typing information for the compiler.

The compiler also needs the database to look up data typing information.